### PR TITLE
Allow onChange props to change

### DIFF
--- a/src/Place.js
+++ b/src/Place.js
@@ -20,7 +20,7 @@ class Places extends Component {
     }
         
     const autocomplete = place(options);
-    autocomplete.on('change', this.props.onChange);
+    autocomplete.on('change', (e) => this.props.onChange(e));
   }
     
   render() {
@@ -51,7 +51,7 @@ Places.defaultProps = {
   disabled: false,
   language: navigator.language,
   useDeviceLocation: false,
-  onChange: (query, rawAnswer, suggestion, suggestionIndex) => console.log(query, rawAnswer, suggestion, suggestionIndex),
+  onChange: (e) => console.log(e),
     
 };
 


### PR DESCRIPTION
The current implementation silently ignores changes to the onChange props. The function reference is passed only on mount and subsequent changes to the props are ignored.

I also noted that the api of onChange takes just 1 param (the event), and I updated that.
https://community.algolia.com/places/examples.html#complete-form